### PR TITLE
fix: correct invalied->invalid typo in error message

### DIFF
--- a/zbook_backend/gapi/repo_auto_sync_repo.go
+++ b/zbook_backend/gapi/repo_auto_sync_repo.go
@@ -30,7 +30,7 @@ func (server *Server) AutoSyncRepo(ctx context.Context, req *rpcs.AutoSyncRepoRe
 		return nil, status.Errorf(codes.PermissionDenied, "this repo not set auto sync token")
 	}
 	if repo.SyncToken.String != req.GetSyncToken() {
-		return nil, status.Errorf(codes.InvalidArgument, "invalied sync token")
+		return nil, status.Errorf(codes.InvalidArgument, "invalid sync token")
 	}
 
 	arg := db.ManualSyncRepoTxParams{


### PR DESCRIPTION
Fixes `invalied` → `invalid` typo in `zbook_backend/gapi/repo_auto_sync_repo.go` line 33:

`status.Errorf(codes.InvalidArgument, "invalied sync token")` → `status.Errorf(codes.InvalidArgument, "invalid sync token")`

This is a gRPC error message shown to users when the sync token is invalid.